### PR TITLE
added manager_only attribute for insight function

### DIFF
--- a/flask_project/campaign_manager/insights_functions/_abstract_insights_function.py
+++ b/flask_project/campaign_manager/insights_functions/_abstract_insights_function.py
@@ -37,6 +37,8 @@ class AbstractInsightsFunction(object):
     need_feature = True
     need_required_attributes = True
 
+    manager_only = False
+
     def __init__(self, campaign, feature=None, required_attributes=None, additional_data={}):
         self.campaign = campaign
         if not self.feature:

--- a/flask_project/campaign_manager/insights_functions/upload_coverage.py
+++ b/flask_project/campaign_manager/insights_functions/upload_coverage.py
@@ -15,6 +15,7 @@ class UploadCoverage(AbstractInsightsFunction):
     category = ['coverage']
     need_feature = False
     need_required_attributes = False
+    manager_only = True
 
     def initiate(self, additional_data):
         """ Initiate function

--- a/flask_project/campaign_manager/models/campaign.py
+++ b/flask_project/campaign_manager/models/campaign.py
@@ -76,6 +76,11 @@ class Campaign(JsonModel):
         :return: Get selected function in string
         :rtype: str
         """
+        for key, value in self.selected_functions.items():
+            SelectedFunction = getattr(
+                insights_functions, value['function'])
+            selected_function = SelectedFunction(self)
+            value['manager_only'] = selected_function.manager_only
         return json.dumps(self.selected_functions).replace('None', 'null')
 
     def parse_json_file(self):
@@ -96,34 +101,6 @@ class Campaign(JsonModel):
                         setattr(self, key, value)
             except json.decoder.JSONDecodeError:
                 raise JsonModel.CorruptedFile
-
-    def insight_function_data(self, insight_function_id):
-        """Get data from insight_function
-
-        :param insight_function_id: id of insight function
-        :type insight_function_id: str
-
-        :return: data from insight function
-        :rtype: dict
-        """
-        if insight_function_id not in self.selected_functions:
-            raise Campaign.InsightsFunctionNotAssignedToCampaign
-        try:
-            function = self.selected_functions[insight_function_id]
-            SelectedFunction = getattr(
-                insights_functions, function['function'])
-            selected_function = SelectedFunction(
-                self,
-                feature=function['feature'],
-                required_attributes=function['attributes'])
-            selected_function.run()
-            output = {
-                'title': selected_function.name(),
-                'data': selected_function.get_function_data()
-            }
-            return output
-        except AttributeError as e:
-            return {}
 
     def render_insights_function(self, insight_function_id, additional_data={}):
         """Get rendered UI from insight_function

--- a/flask_project/campaign_manager/templates/campaign_detail.html
+++ b/flask_project/campaign_manager/templates/campaign_detail.html
@@ -206,21 +206,37 @@
     <script>
 
         var uuid = '{{ uuid }}';
+        var managers = {{ campaign_managers|safe }};
         var selected_functions = {{ selected_functions | safe }};
         var feature_collected = [];
         var feature_collected_count = 0;
 
         $(function () {
             $('#features').LoadingOverlay("show", {image: "/campaign_manager/static/resources/loading-spinner.gif"});
-            $.each(selected_functions, function (key, selected_function) {
-                get_function(key);
-                if (!containsObject(selected_function['feature'], feature_collected)) {
-                    feature_collected.push(selected_function['feature']);
-                    if (selected_function["category"] != "coverage-function") {
-                        get_metadata(key);
+
+            profile_updated = function (profile_name) {
+                $.each(selected_functions, function (key, selected_function) {
+                    var allow_function = true;
+                    if (selected_function['manager_only']) {
+                        if ($.inArray(profile_name, managers) === -1) {
+                            allow_function = false;
+                        }
                     }
-                }
-            });
+                    if (allow_function) {
+                        get_function(key);
+                        if (!containsObject(selected_function['feature'], feature_collected)) {
+                            feature_collected.push(selected_function['feature']);
+                            if (selected_function["category"] != "coverage-function") {
+                                get_metadata(key);
+                            }
+                        }
+                    }
+                });
+            };
+            window.isAuthenticated = auth.authenticated();
+            if (!auth.authenticated()) {
+                update();
+            }
         });
 
         var drawnItems = new L.FeatureGroup();

--- a/flask_project/campaign_manager/templates/campaign_detail.html
+++ b/flask_project/campaign_manager/templates/campaign_detail.html
@@ -203,7 +203,7 @@
 
     <script src="/campaign_manager/static/libs/chartjs/Chart.bundle.min.js"></script>
 
-    <script>
+    <script type="text/javascript">
 
         var uuid = '{{ uuid }}';
         var managers = {{ campaign_managers|safe }};
@@ -211,28 +211,45 @@
         var feature_collected = [];
         var feature_collected_count = 0;
 
+        function render_selected_functions(username) {
+
+            $('.insight-tabs').html('');
+            $('.insight-content').html('');
+            $.each(selected_functions, function (key, selected_function) {
+                var allow_function = true;
+                if (selected_function['manager_only']) {
+                    if ($.inArray(username, managers) === -1) {
+                        allow_function = false;
+                    }
+                }
+                if (allow_function) {
+                    get_function(key);
+                    if (!containsObject(selected_function['feature'], feature_collected)) {
+                        feature_collected.push(selected_function['feature']);
+                        if (selected_function["category"] != "coverage-function") {
+                            get_metadata(key);
+                        }
+                    }
+                }
+            });
+        }
+        //------------------ EVENT ------------------//
+
+        function loginSuccess(user) {
+            render_selected_functions(user.display_name);
+        }
+
+        function loginError() {
+            render_selected_functions('');
+        }
+
+        function logoutSuccess() {
+            render_selected_functions('');
+        }
+
         $(function () {
             $('#features').LoadingOverlay("show", {image: "/campaign_manager/static/resources/loading-spinner.gif"});
 
-            profile_updated = function (profile_name) {
-                $.each(selected_functions, function (key, selected_function) {
-                    var allow_function = true;
-                    if (selected_function['manager_only']) {
-                        if ($.inArray(profile_name, managers) === -1) {
-                            allow_function = false;
-                        }
-                    }
-                    if (allow_function) {
-                        get_function(key);
-                        if (!containsObject(selected_function['feature'], feature_collected)) {
-                            feature_collected.push(selected_function['feature']);
-                            if (selected_function["category"] != "coverage-function") {
-                                get_metadata(key);
-                            }
-                        }
-                    }
-                });
-            };
             window.isAuthenticated = auth.authenticated();
             if (!auth.authenticated()) {
                 update();
@@ -263,6 +280,9 @@
             $.ajax({
                 url: url,
                 success: function (data) {
+                    var href = "#" + function_id
+                    $('.insight-tabs').find('a[href="' + href + '"]').closest('li').remove();
+                    $('.insight-content').find('#' + function_id).remove();
                     var active = '';
                     if (first_function) {
                         active = 'active';
@@ -273,7 +293,7 @@
 
                     $('.insight-tabs').append(
                             '<li class="' + active + '">' +
-                            '<a href="#' + function_id + '" data-toggle="tab" aria-expanded="true">' +
+                            '<a href="' + href + '" data-toggle="tab" aria-expanded="true">' +
                             $insightTitle.html() + '</a>' +
                             '</li>'
                     );
@@ -283,6 +303,7 @@
                             data +
                             '</div>'
                     );
+                    $('.insight-tabs').find('a')[0].click();
 
                 }
             });

--- a/flask_project/campaign_manager/templates/campaign_widget/ui/feature_completeness.html
+++ b/flask_project/campaign_manager/templates/campaign_widget/ui/feature_completeness.html
@@ -3,7 +3,7 @@
     <div class="progress-bar-wrapper">
         <div class="progress-bar" style="width: {{ data.percentage }}%"></div>
     </div>
-    <div class="see-detail" onclick="see_completeness_details(this)">see detail</div>
+    <div class="see-detail" onclick="see_completeness_details(this)"><i class="fa fa-caret-down" aria-hidden="true"></i> see list of incomplete features</div>
     <table class="feature-list-table">
         <thead>
             <tr>
@@ -11,30 +11,26 @@
                 {% for key in data.attributes %}
                     <th>{{ key }}</th>
                 {% endfor %}
-                <th>Completeness</th>
             </tr>
         </thead>
         <tbody>
             {% for row in data.data %}
-                <tr>
-                    <td><a target="_blank" href="http://www.openstreetmap.org/{{ row['type'] }}/{{ row['id'] }}">{{ row['id'] }}</a></td>
-                    {% for key in data.attributes %}
-                        {% if not row['tags'] %}
-                            <td>-</td>
-                        {% elif row['tags'][key] %}
-                            <td>{{ row['tags'][key] }}</td>
-                        {% elif row[key] %}
-                            <td>{{ row[key] }}</td>
-                        {% else %}
-                            <td>-</td>
-                        {% endif %}
-                    {% endfor %}
-                    {% if row['error'] %}
-                        <td class="error-indicator">Incomplete</td>
-                    {% else %}
-                        <td class="clean-indicator">Complete</td>
-                    {% endif %}
-                </tr>
+                {% if row['error'] %}
+                    <tr>
+                        <td><a target="_blank" href="http://www.openstreetmap.org/{{ row['type'] }}/{{ row['id'] }}">{{ row['id'] }}</a></td>
+                        {% for key in data.attributes %}
+                            {% if not row['tags'] %}
+                                <td>-</td>
+                            {% elif row['tags'][key] %}
+                                <td>{{ row['tags'][key] }}</td>
+                            {% elif row[key] %}
+                                <td>{{ row[key] }}</td>
+                            {% else %}
+                                <td>-</td>
+                            {% endif %}
+                        {% endfor %}
+                    </tr>
+                {% endif %}
             {% endfor %}
         </tbody>
     </table>
@@ -43,7 +39,6 @@
     .see-detail {
         width: 100%;
         text-align: center;
-        color: gray;
         cursor: pointer;
         margin: 10px;
     }
@@ -94,10 +89,10 @@
     });
     function see_completeness_details(event) {
         if (!$(event).closest(".completness").find(".dataTables_wrapper").is(":visible")) {
-            $(event).html("Hide detail");
+            $(event).html('<i class="fa fa-caret-up" aria-hidden="true"></i> hide list of incomplete features');
             $(event).closest(".completness").find(".dataTables_wrapper").show();
         } else {
-            $(event).html("See detail");
+            $(event).html('<i class="fa fa-caret-down" aria-hidden="true"></i> see list of incomplete features');
             $(event).closest(".completness").find(".dataTables_wrapper").hide();
         }
     }

--- a/flask_project/campaign_manager/templates/new_base.html
+++ b/flask_project/campaign_manager/templates/new_base.html
@@ -107,8 +107,6 @@
             auto: true,
             landing: window.location.origin + '/campaign_manager/land'
         });
-        var profile_updated = function(profile_name) {
-        };
 
         $(document).ready(function () {
             $('#login-menu').click(function () {
@@ -161,7 +159,7 @@
             }, function (err, res) {
                 if (err) {
                     $('#info').html('error! try clearing your browser cache');
-                    profile_updated('');
+                    loginError();
                     return;
                 }
                 var u = res.getElementsByTagName('user')[0];
@@ -190,13 +188,10 @@
                     }
                 }
 
-                if(loginProcess) {
-                    loginSuccess(o);
-                    loginProcess = false;
-                }
+                loginSuccess(o);
+                loginProcess = false;
 
                 hideLoading();
-                profile_updated(o.display_name);
             }, this);
         }
         function hideDetails(map) {
@@ -211,12 +206,15 @@
                     map.setView([0, 0], 1);
                 }
             }
-            profile_updated('');
+            loginError();
         }
 
         update();
 
         function loginSuccess(user) {
+        }
+
+        function loginError(user) {
         }
 
         function logoutSuccess() {

--- a/flask_project/campaign_manager/templates/new_base.html
+++ b/flask_project/campaign_manager/templates/new_base.html
@@ -107,6 +107,8 @@
             auto: true,
             landing: window.location.origin + '/campaign_manager/land'
         });
+        var profile_updated = function(profile_name) {
+        };
 
         $(document).ready(function () {
             $('#login-menu').click(function () {
@@ -159,6 +161,7 @@
             }, function (err, res) {
                 if (err) {
                     $('#info').html('error! try clearing your browser cache');
+                    profile_updated('');
                     return;
                 }
                 var u = res.getElementsByTagName('user')[0];
@@ -193,9 +196,9 @@
                 }
 
                 hideLoading();
+                profile_updated(o.display_name);
             }, this);
         }
-
         function hideDetails(map) {
             $('#login-menu').show();
             $('#logout-menu').hide();
@@ -208,6 +211,7 @@
                     map.setView([0, 0], 1);
                 }
             }
+            profile_updated('');
         }
 
         update();


### PR DESCRIPTION
this fixes #54, fixes #52 

only show incomplete
![selection_068](https://cloud.githubusercontent.com/assets/4530905/26575932/526c821c-4551-11e7-8b6e-9659a8bb75bf.png)

For manager only insight function, added new attribute for insight function (manager_only, default is false). It will not show if profile_name of osm is not in manager of campaign.
Because we don't have session in the backend, the idea is now we are waiting for getting profile detail, after that render insight function based on the rule of manager_only. 
Show if:
- manager_only is false
- manager_only is true and profile_name is in manager of campaign
