### PR TITLE
update boundary uploader to just receive single polygon

### DIFF
--- a/flask_project/campaign_manager/data_providers/shapefile_provider.py
+++ b/flask_project/campaign_manager/data_providers/shapefile_provider.py
@@ -11,6 +11,13 @@ from campaign_manager.data_providers._abstract_data_provider import (
 class ShapefileProvider(AbstractDataProvider):
     """Provider from overpass"""
 
+    @staticmethod
+    class MultiPolygonFound(Exception):
+        def __init__(self):
+            self.message = "Shapefile should be in single polygon."
+            super(ShapefileProvider.MultiPolygonFound, self).__init__(
+                self.message)
+
     def get_data(self, shapefile_file):
         """Get shapefile data.
 
@@ -34,7 +41,7 @@ class ShapefileProvider(AbstractDataProvider):
                 try:
                     feature['properties']['date'] = \
                         feature['properties']['date'].strftime('%Y-%m-%d')
-                except AttributeError:
+                except (AttributeError, KeyError):
                     pass
             return {
                 "type": "FeatureCollection",

--- a/flask_project/campaign_manager/templates/campaign_widget/ui/upload_boundary.html
+++ b/flask_project/campaign_manager/templates/campaign_widget/ui/upload_boundary.html
@@ -4,7 +4,10 @@
         </div>
         <div class="file-indicator">
         </div>
-        <div style="color: gray; font-style: italic; text-align: center; margin-bottom: 10px">Multiselect .dbf, .shp, .shx for minimum files.</div>
+        <div style="color: gray; font-style: italic; text-align: center; margin-bottom: 10px">
+            Boundary should be single polygon.<br>
+            Multiselect .dbf, .shp, .shx for minimum files.
+        </div>
         <div class="btn-group" style="width: 100%">
             <div class="add-file btn btn-outline btn-primary btn-lg">
                 <span>Add file(s)</span>


### PR DESCRIPTION
This fix #126 

Restrict upload boundary form for just single shapefile
![selection_009](https://user-images.githubusercontent.com/4530905/27316870-e6f64592-55ac-11e7-866c-0da1e64dec0d.png)
![selection_010](https://user-images.githubusercontent.com/4530905/27316871-e6fac4e6-55ac-11e7-8fd1-95b274080262.png)
![selection_011](https://user-images.githubusercontent.com/4530905/27316872-e70234e2-55ac-11e7-94dd-79de48e0653c.png)
