### PR TITLE
add date validator

### DIFF
--- a/flask_project/campaign_manager/static/css/create-campaign.css
+++ b/flask_project/campaign_manager/static/css/create-campaign.css
@@ -305,8 +305,15 @@
     height: 50pt !important;
 }
 
-#campaign-form input#name {
+#campaign-form textarea#description {
     margin-top: 25px;
+}
+
+#campaign-form input#name {
+    border: none !important;
+    box-shadow: none !important;
+    height: 25px !important;
+    padding: 0 !important;
 }
 
 .form-body.col-lg-3 {

--- a/flask_project/campaign_manager/static/css/create-campaign.css
+++ b/flask_project/campaign_manager/static/css/create-campaign.css
@@ -326,7 +326,8 @@
 }
 
 #campaign-form input::placeholder, #campaign-form textarea::placeholder {
-  font-size: 11pt;
+    font-size: 11pt;
+    font-weight: normal !important;
 }
 
 #campaign-form select#tags {
@@ -401,4 +402,13 @@ select.dashboard-settings {
 #list-projects .panel-default {
     border-top: 1px solid #ddd !important;
     margin-top: 10px;
+}
+
+input#start_date.form-control.error::placeholder,
+input#end_date.form-control.error::placeholder {
+    font-size: 10pt !important;
+}
+
+input#name {
+    font-weight: 700 !important;
 }

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -157,7 +157,7 @@
                                 </div>
                             </div>
                             <div class="cc-buttons">
-                                <button type="button" class="btn btn-next pull-right">Next <span class="pull-right"> > </span></button>
+                                <button type="button" class="btn btn-next pull-right" onclick="checkFormHeader()">Next <span class="pull-right"> > </span></button>
                             </div>
                         </fieldset>
 
@@ -696,6 +696,34 @@
             }
 
             return valid;
+        }
+
+        function checkFormHeader(){
+                        var valid = true;
+
+            var required_forms = $('.form-header').find('.required-form');
+
+            $.each(required_forms, function (index, value) {
+                var input_form = $(value).find("[type=text]");
+
+                if (input_form.length > 0) {
+                    input_form.removeClass('error');
+
+                    input_form.click(function () {
+                        $(this).removeClass('error');
+                        $(this).attr('placeholder', '');
+                    });
+
+                    if (input_form.val() === '') {
+                        input_form.addClass('error');
+                        input_form.attr('placeholder', 'This field is required');
+                        valid = false;
+                    }
+                }
+            });
+
+            return valid;
+
         }
 
         $(function () {

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -157,7 +157,7 @@
                                 </div>
                             </div>
                             <div class="cc-buttons">
-                                <button type="button" class="btn btn-next pull-right" onclick="checkFormHeader()">Next <span class="pull-right"> > </span></button>
+                                <button type="button" class="btn btn-next pull-right">Next <span class="pull-right"> > </span></button>
                             </div>
                         </fieldset>
 
@@ -515,11 +515,12 @@
             if (currentStep === totalSteps) return;
 
             nextStep = checkSteps(currentStep);
+            var nameDateValid = checkFormHeader();
 
             // scroll window to beginning of the form
             scrollToClass($('#wrapper'), 20);
 
-            if (nextStep) {
+            if (nextStep && nameDateValid) {
                 $(parentFieldset).children().find('button').attr('disabled', 'disabled');
                 $('#fieldset-' + currentFieldsetNumber).fadeOut(400, function () {
                     // change icons
@@ -699,8 +700,7 @@
         }
 
         function checkFormHeader(){
-                        var valid = true;
-
+            var valid = true;
             var required_forms = $('.form-header').find('.required-form');
 
             $.each(required_forms, function (index, value) {

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -34,8 +34,8 @@
                     <div><i class="fa fa-map"></i><span>&nbsp;&nbsp;Remote Mapping</span>
                     <span class="cc-nav-icon pull-right" style="display: none"><i class="fa fa-check"></i></span></div>
                 </div>
-                <div><span class="panel-header-info cc-functions hide" style="margin-left: 25px">FUNCTIONS</span></div>
-                <div class="panel panel-default panel-header cc-functions cc-nav hide" data-step="3">
+                <div><span class="panel-header-info" style="margin-left: 25px">FUNCTIONS</span></div>
+                <div class="panel panel-default panel-header cc-nav" data-step="3">
                     <div><p><i class="fa fa-paint-brush"></i><span>&nbsp;&nbsp;Coverage Function</span>
                     <span class="cc-nav-icon pull-right" style="display: none"><i class="fa fa-check"></i></span></p></div>
                 </div>
@@ -54,7 +54,7 @@
             </div>
             <div class="panel panel-default panel-header" style="border-top: 1px solid #ddd !important;">
                 <span class="panel-header-info">DASHBOARD SETTINGS</span><br/>
-                <select class="dashboard-settings" id="dashboard-settings" onchange="changeDashboard()">
+                <select class="dashboard-settings minimal" id="dashboard-settings" onchange="changeDashboard()">
                     <option value="basic">Basic</option>
                     <option value="advanced">Advanced</option>
                 </select>
@@ -69,11 +69,9 @@
                                     <div class="form-header col-lg-9">
                                         <div class="panel panel-default panel-header">
                                             <span class="panel-header-info">NAME</span><br/>
-                                            {% if form.name.data %}
-                                                <span class="campaign-name-header">{{ form.name.data }}</span>
-                                            {% else %}
-                                                <span class="campaign-name-header">New Campaign</span>
-                                            {% endif %}
+                                            <div class="form-group required-form">
+                                                {{ form.name }}
+                                            </div>
                                         </div>
                                     </div>
                                     <div class="form-header col-lg-3">
@@ -98,10 +96,6 @@
                         <fieldset id="fieldset-1" data-fieldset-step="1">
                             <div class="row">
                                 <div class="form-body col-lg-9">
-                                    <div class="form-group required-form">
-                                        {{ form.name }}
-                                    </div>
-                                    <br/>
                                     <div class="form-group">
                                         {{ form.description }}
                                     </div>
@@ -286,7 +280,7 @@
                                 <input id="submit" name="submit" type="submit" value="Submit" class="btn submit-button">
                             </div>
                             <div class="col-lg-4">
-                                <button type="button" class="hide cc-functions btn btn-next pull-right">Next <span class="pull-right"> > </span></button>
+                                <button type="button" class="btn btn-next pull-right">Next <span class="pull-right"> > </span></button>
                             </div>
                         </div>
                     </fieldset>
@@ -318,7 +312,7 @@
                                     </div>
                                     <div class="col-lg-4">
                                         {% if loop.index < categories|length %}
-                                            <button type="button" class="btn btn-next pull-right">Next <span class="pull-right"> > </span></button>
+                                            <button type="button" class="btn btn-next pull-right cc-functions hide">Next <span class="pull-right"> > </span></button>
                                         {% endif %}
                                     </div>
                                 </div>
@@ -836,12 +830,20 @@
         $("#end_date").attr('data-language', 'en');
         $("#start_date").datepicker({
             dateFormat: 'yyyy-mm-dd',
-            autoClose: true
+            autoClose: true,
+            onSelect: function(date) {
+                $("#end_date").val(date);
+                $("#end_date").datepicker({ minDate: new Date(date) })
+            }
         });
         $("#end_date").datepicker({
             dateFormat: 'yyyy-mm-dd',
             autoClose: true,
-            position: 'bottom right'
+            position: 'bottom right',
+            onSelect: function(date){
+                $("#start_date").val(date);
+                $("#start_date").datepicker({ maxDate: new Date(date) })
+            }
         });
 
         campaignMap.fitBounds(bounds);

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -728,6 +728,7 @@
 
         $(function () {
 
+            $('input#name').focus();
             $(document).tooltip({
                 selector: "[data-toggle=tooltip]",
                 container: "body"


### PR DESCRIPTION
fix #158 

Start date can be picked until `end date`
![screenshot from 2017-07-10 17-17-44](https://user-images.githubusercontent.com/26101337/28014974-4ebc47a8-6598-11e7-9efa-c05685e99ac3.png)

End date can be picked start from `start date`
![screenshot from 2017-07-10 17-17-28](https://user-images.githubusercontent.com/26101337/28014948-38543f98-6598-11e7-88f5-fe1f0a81e33d.png)

note: this PR also change the position of campaign name input in the form