### PR TITLE
strict edit view for managers

### DIFF
--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -641,7 +641,7 @@
             {% if action == 'edit' %}
                 var is_manager = $.inArray(response.display_name, managers_list);
                 if(is_manager == -1){
-                    location.href='/';
+                    location.href='/404';
                 }
             {% endif %}
             $('#campaign-panel').show();

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block content %}
-    <div class="row">
+    <div class="row" id="form-panel">
         <div class="col-lg-2">
             <div class="panel panel-default panel-header">
                 <span class="panel-header-info">STATUS</span><br/>
@@ -521,6 +521,7 @@
                 })
             }
         }
+        $('#form-panel').hide();
         $(function () {
             updateManagerList();
         });
@@ -642,9 +643,14 @@
                 var is_manager = $.inArray(response.display_name, managers_list);
                 if(is_manager == -1){
                     location.href='/404';
+                }else {
+                    $('#form-panel').show();
+                    $('#campaign-panel').show();
                 }
+            {% else %}
+                $('#form-panel').show();
+                $('#campaign-panel').show();
             {% endif %}
-            $('#campaign-panel').show();
             {% if action == 'create' %}
                 managers_list.push(response.display_name);
                 $('#managers-list').append(
@@ -664,7 +670,10 @@
         if (!window.isAuthenticated) {
             window.location.replace("/");
         } else {
-            $('#campaign-panel').show();
+            {% if action=='create' %}
+                $('#form-panel').show();
+                $('#campaign-panel').show();
+            {% endif %}
         }
 
         //------------------ STEPS ------------------//

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -638,6 +638,12 @@
         }
 
         function updated(response) {
+            {% if action == 'edit' %}
+                var is_manager = $.inArray(response.display_name, managers_list);
+                if(is_manager == -1){
+                    location.href='/';
+                }
+            {% endif %}
             $('#campaign-panel').show();
             {% if action == 'create' %}
                 managers_list.push(response.display_name);


### PR DESCRIPTION
fix #369 

In the edit view, when the user is not the manager of the campaign, he will be redirected to 404.
![peek 2017-09-27 16-14](https://user-images.githubusercontent.com/26101337/30905512-3ca78f56-a39f-11e7-9a2e-2a46f3c41562.gif)

for the manager, edit is working as usual
![peek 2017-09-27 16-15](https://user-images.githubusercontent.com/26101337/30905531-4961f8b2-a39f-11e7-8718-1813a737987c.gif)
