### PR TITLE
change overpass server url

### DIFF
--- a/flask_project/campaign_manager/data_providers/overpass_provider.py
+++ b/flask_project/campaign_manager/data_providers/overpass_provider.py
@@ -100,7 +100,9 @@ class OverpassProvider(AbstractDataProvider):
         """
         default_server_url = 'http://exports-prod.hotosm.org:6080/api/' \
                              'interpreter'
-        attic_data_server_url = 'http://overpass-api.de/api/interpreter'
+        attic_data_server_url = 'http://' \
+                                'ec2-54-172-198-122.compute-1.amazonaws.com/' \
+                                'api/interpreter'
 
         if need_attic_data:
             server_url = attic_data_server_url
@@ -293,7 +295,8 @@ class OverpassProvider(AbstractDataProvider):
         :rtype: dict
         """
 
-        server_url = 'http://overpass-api.de/api/interpreter'
+        server_url = 'http://ec2-54-172-198-122.compute-1.amazonaws.com/' \
+                     'api/interpreter'
 
         query = self.parse_url_parameters(
                 polygon=polygon,


### PR DESCRIPTION
Tried this in my local.
Using `http://ec2-54-172-198-122.compute-1.amazonaws.com/api/interpreter` is better at acquiring data. As using the previous one, sometimes I get `network error` when loading the campaign, but not using this one.