### PR TITLE
Fix download josm

### DIFF
--- a/flask_project/campaign_manager/test/test_utilities.py
+++ b/flask_project/campaign_manager/test/test_utilities.py
@@ -4,6 +4,7 @@ from campaign_manager.utilities import (
     cast_element_ids_to_s
 )
 
+
 class UtilitiesTestCase(unittest.TestCase):
     """Test Utilities functions"""
 
@@ -36,7 +37,6 @@ class UtilitiesTestCase(unittest.TestCase):
         expected_elements_parameters = 'node(id:1234,5678,9123);'
         elements_parameters = cast_element_ids_to_s(elements)
         self.assertEqual(elements_parameters, expected_elements_parameters)
-
 
     def test_cast_element_ids_to_s_with_only_relation_elements(self):
         """

--- a/flask_project/campaign_manager/test/test_utilities.py
+++ b/flask_project/campaign_manager/test/test_utilities.py
@@ -1,0 +1,89 @@
+# coding=utf-8
+import unittest
+from campaign_manager.utilities import (
+    cast_element_ids_to_s
+)
+
+class UtilitiesTestCase(unittest.TestCase):
+    """Test Utilities functions"""
+
+    def test_cast_element_ids_with_empty_elements(self):
+        """
+        When there isnt node, relation or way in elements
+        It should return an empty string
+        """
+        elements = {
+            'node': [],
+            'relation': [],
+            'way': []
+        }
+
+        expected_elements_parameters = str()
+        elements_parameters = cast_element_ids_to_s(elements)
+        self.assertEqual(elements_parameters, expected_elements_parameters)
+
+    def test_cast_element_ids_to_s_with_only_node_elements(self):
+        """
+        when elements only contain node ids
+        It should only return node ids
+        """
+        elements = {
+            'node': [1234, 5678, 9123],
+            'relation': [],
+            'way': []
+        }
+
+        expected_elements_parameters = 'node(id:1234,5678,9123);'
+        elements_parameters = cast_element_ids_to_s(elements)
+        self.assertEqual(elements_parameters, expected_elements_parameters)
+
+
+    def test_cast_element_ids_to_s_with_only_relation_elements(self):
+        """
+        when elements only contain relation ids
+        It should only return relation ids
+        """
+
+        elements = {
+            'node': [],
+            'relation': [1234, 5678, 9123],
+            'way': []
+        }
+
+        expected_elements_parameters = 'relation(id:1234,5678,9123);'
+        elements_parameters = cast_element_ids_to_s(elements)
+        self.assertEqual(elements_parameters, expected_elements_parameters)
+
+    def test_cast_element_ids_to_s_with_only_way_elements(self):
+        """
+        when elements only contain way ids
+        It should only return way ids
+        """
+
+        elements = {
+            'node': [],
+            'relation': [],
+            'way': [1234, 5678, 9123]
+        }
+
+        expected_elements_parameters = 'way(id:1234,5678,9123);'
+        elements_parameters = cast_element_ids_to_s(elements)
+        self.assertEqual(elements_parameters, expected_elements_parameters)
+
+    def test_cast_element_ids_to_s_with_all_elements(self):
+        """
+        when elements contains node, relation and way
+        It should node, relation and way ids
+        """
+
+        elements = {
+            'node': [1234, 5678, 9012],
+            'relation': [2345, 6789, 1124],
+            'way': [3456, 7890, 1123]
+        }
+
+        expected_elements_parameters = 'node(id:1234,5678,9012);' + \
+            'relation(id:2345,6789,1124);' + \
+            'way(id:3456,7890,1123);'
+        elements_parameters = cast_element_ids_to_s(elements)
+        self.assertEqual(elements_parameters, expected_elements_parameters)

--- a/flask_project/campaign_manager/utilities.py
+++ b/flask_project/campaign_manager/utilities.py
@@ -327,4 +327,3 @@ def cast_element_ids_to_s(hash_element_ids):
             elements_to_s += el_to_s
 
     return elements_to_s
-

--- a/flask_project/campaign_manager/utilities.py
+++ b/flask_project/campaign_manager/utilities.py
@@ -305,3 +305,26 @@ def get_coordinate_from_ip():
     response = requests.get(url)
     data = response.json()
     return data['loc']
+
+
+def cast_element_ids_to_s(hash_element_ids):
+    """ Cast a hash of element ids to a string of element ids.
+
+    :param hash_element_ids: node/relation/way ids
+    :type hash_element_ids: hash
+
+    :returns: a string of node/relation/way ids
+    :rtype: str
+    """
+    elements_to_s = str()
+    for el in ['node', 'relation', 'way']:
+        if len(hash_element_ids[el]) > 0:
+            el_to_s = '{}(id:{});'.format(
+                el,
+                ','.join(str(element)
+                         for element in hash_element_ids[el]))
+
+            elements_to_s += el_to_s
+
+    return elements_to_s
+


### PR DESCRIPTION
Hi,
There was a bug when clicking on the button 'Download JOSM file' on a Campaign page.
For my first pull request to the project, I decided to quickly fix it and clean a bit the code. 

The error was: 'TypeError: sequence item 0: expected str instance, int found'.
The error appeared when building the request to send to OverpassQuery.
There was an issue when casting an integer to a string. 

I moved the code that was previously in overpass_provider.py to a function in utilities.py for better clarity. It is also easier to test it.

Now, we're able to download the JOSM file.