### PR TITLE
add yaml survey editor

### DIFF
--- a/flask_project/campaign_manager/static/css/create-campaign.css
+++ b/flask_project/campaign_manager/static/css/create-campaign.css
@@ -534,7 +534,7 @@ input#map_type {
 }
 
 input#btn-add {
-    width: 160px !important;
+    width: 207px !important;
     height: 35px !important;
     border-radius: 5px !important;
     background-color: #EBEBEB;

--- a/flask_project/campaign_manager/static/js/create/campaign-json-handler.js
+++ b/flask_project/campaign_manager/static/js/create/campaign-json-handler.js
@@ -35,8 +35,6 @@ function assignCampaignJsonToForm(json) {
     // check remote projects
     if (jQuery.type(json['remote_projects']) === "array") {
         $('#list-added-projects').each(function (index, element) {
-            console.log($(element));
-            console.log($(element).find('.btn-danger'));
             $(element).find('.btn-danger').click();
         });
         $.each(json['remote_projects'], function (index, remote_project_id) {

--- a/flask_project/campaign_manager/static/js/create/types_tags.js
+++ b/flask_project/campaign_manager/static/js/create/types_tags.js
@@ -242,6 +242,9 @@ function addTag(wrapper) {
 function removeTags(event, type) {
     $(event).parent().parent().remove();
     $('#insight-function .function-form').html('');
+    if (types[type]['custom']) {
+        delete types[type];
+    }
 }
 
 function removeIndividualTag(event, type) {

--- a/flask_project/campaign_manager/templates/create_campaign.html
+++ b/flask_project/campaign_manager/templates/create_campaign.html
@@ -128,7 +128,9 @@
                             <div class="row">
                                 <div class="form-body form-group col-lg-4" style="margin-top: 10px">
                                     <input id="btn-add" type="button" value="+ Choose a template" onclick="addTypes()">
-                                    <input id="btn-add" type="button" value="+ Add custom tags" style="margin-top: 10px" data-toggle="modal" data-target="#custom-types-tags">
+                                    <input id="btn-add" type="button" value="+ Add custom type" style="margin-top: 10px" data-toggle="modal" data-target="#custom-types-tags">
+                                    <input id="btn-add" type="button" value="Edit custom types in yaml"
+                                           style="margin-top: 10px" data-format="all-yaml" data-toggle="modal" data-target="#custom-types-tags">
                                 </div>
                             </div>
                             <!-- Managers -->
@@ -457,6 +459,7 @@
 
     <script type="text/javascript" src="/static/js/leaflet.draw-0.4.9/leaflet.draw.js"></script>
     <script src="//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.8.3/underscore-min.js"></script>
+    <script src="https://cdnjs.cloudflare.com/ajax/libs/js-yaml/3.12.0/js-yaml.min.js"></script>
     <script type="text/javascript" src="/static/js/create/map.js"></script>
     <script type="text/javascript" src="/static/js/create/remote_mapping.js"></script>
     <script type="text/javascript" src="/static/js/create/types_tags.js"></script>

--- a/flask_project/campaign_manager/templates/modals/custom-types-and-tags.html
+++ b/flask_project/campaign_manager/templates/modals/custom-types-and-tags.html
@@ -1,10 +1,14 @@
 <!-- Modal -->
 <style>
+    #yaml-format {
+        display: none;
+    }
+
     .modal-content {
         background-color: #f7f7f7 !important;
     }
 
-    .modal-required-message {
+    .modal-required-message, .modal-error-message {
         display: none;
         color: #ac3232;
     }
@@ -40,10 +44,20 @@
         padding-left: 20px;
     }
 
+    .help {
+        margin-top: 10px;
+        margin-bottom: 10px;
+        text-align: left;
+    }
+
+    .modal-footer .modal-required-message {
+        text-align: center;
+        margin-top: 10px;
+    }
+
 </style>
 <div id="custom-types-tags" class="modal fade" role="dialog">
-    <div class="modal-dialog">
-
+    <div id="easy-format" class="modal-dialog">
         <!-- Modal content-->
         <div class="modal-content">
             <div class="modal-header">
@@ -84,11 +98,78 @@
                 </div>
             </div>
             <div class="modal-footer">
+                <button type="button" class="btn btn-default btn-orange" onclick="switchToYamlFormat()">Switch to yaml format</button>
                 <button type="button" id="btn-add-custom-type" class="btn btn-default btn-orange" onclick="saveCustomType()">Add</button>
                 <button type="button" class="btn btn-default btn-orange" data-dismiss="modal">Close</button>
+                <div class="modal-required-message">This name already registered, please choose other name.</div>
             </div>
         </div>
-
+    </div>
+    <div id="yaml-format" class="modal-dialog">
+        <!-- Modal content-->
+        <div class="modal-content">
+            <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title">+ Add custom types in YAML</h4>
+            </div>
+            <div class="modal-body">
+                <div id="modal-form">
+                    <div class="form-group">
+                        <textarea id="yaml-input" rows="10" placeholder="put yaml types in here" type="text" class="form-control">
+type-1:
+    feature: feature-1
+    tags:
+        - tag-1:
+            - condition-1
+            - condition-2
+        - tag-2
+        - tag-3
+                        </textarea>
+                        <div class="modal-required-message">This field is required</div>
+                        <div class="modal-error-message"></div>
+                        <p class="help-block">
+                            Edit templates in yaml above.
+                        </p>
+                    </div>
+                </div>
+            </div>
+            <div class="modal-footer">
+                <button id="switch-to-easy-format" type="button" class="btn btn-default btn-orange" onclick="switchToEasyFormat()">Switch to easy format</button>
+                <button type="button" id="btn-add-custom-type" class="btn btn-default btn-orange" onclick="saveYamlCustomType()">Add</button>
+                <button type="button" class="btn btn-default btn-orange" data-dismiss="modal">Close</button>
+                <div class="modal-required-message">Some names already registered, please choose other name.</div>
+                <div class="help">
+                    <b>GUIDE :</b>
+                    <pre class="example">
+restaurant:
+    feature: amenity
+    tags:
+        - amenity:
+            - restaurant
+            - fast-food
+        - name
+        - cuisine
+shop:
+    feature: amenity
+    tags:
+        - amenity:
+            - shop
+        - name
+        - opening_hours
+                        </pre>
+                    Put types in yaml format. The formats are:<br>
+                    - Whitespace is sensitive. Each child element must be indented below its parent element.<br>
+                    - The first parent, put <b>title</b> of custom type.<br>
+                    - The second one 2 key, which are feature and tags.<br>
+                    - <b>Feature</b> : This is specific feature of data for this type. For example: building, amenity, etc.<br>
+                    - To make it more specific, add pairing key=value in here. For example: building=school or building=school,university.<br>
+                    - <b>Tags</b> : The format is the list, put dash for every line.
+                    - Tag is the attribute that checked on the feature. For example : name. This will check "name" attribute is exist or not in the feature.
+                    - For specific tag, add new child for that tags (for example amenity). It will check attributes is restaurant or fast-food.
+                    - Can put second type (or more) by creating new parent
+                </div>
+            </div>
+        </div>
     </div>
 </div>
 <script type='text/template' id='_custom_new_tag'>
@@ -118,31 +199,89 @@
     $("#custom_type_feature").keyup(function () {
         addNewCustomTags($(this).val(), true);
     });
-    var lastTypeRow = null;
+    var rowElements = {};
     $('#custom-types-tags').on('show.bs.modal', function (e) {
-        lastTypeRow = null;
+        rowElements = null;
         var relatedTarget = e.relatedTarget;
         var type_selected = $(relatedTarget).closest('.form-group').find('select').val();
         modalReset();
         if (type_selected) {
-            lastTypeRow = $(relatedTarget).closest('.row');
-            var type = types[type_selected];
-            $('#custom_type_name').val(type_selected);
-            $('#custom_type_feature').val(type['feature']);
-            $("#custom_type_feature").trigger("keyup");
-            $.each(type['tags'], function (key, value) {
-                var tag_value = key.replace(': ', '=');
-                if (value.length > 0) {
-                    tag_value += '=' + value.join();
-                }
-                if (type['feature'] != tag_value) {
-                    addNewCustomTags(tag_value)
-                }
-            });
-            $('#custom-types-tags .modal-title').html('Edit custom type');
-            $('#btn-add-custom-type').html('Save');
+            $('#yaml-input').val('');
+            addingCustomTypeForm(type_selected, $(relatedTarget).closest('.row'))
+            $('#custom-types-tags .modal-title').html('Edit custom type of ' + type_selected);
+        } else {
+            if ($(relatedTarget).data('format') == 'all-yaml') {
+                $('#custom-types-tags .modal-title').html('Edit all custom types');
+                $('#switch-to-easy-format').hide();
+                switchToYamlFormat();
+                $('#yaml-input').val('');
+                $('.select-types:disabled').each(function (index, element) {
+                    type_selected = $(element).val();
+                    addingCustomTypeForm(type_selected, element);
+                });
+            }
         }
     });
+    function addingCustomTypeForm(type_selected, element) {
+        rowElements[type_selected] = element;
+        var type = types[type_selected];
+        {# init for easy format #}
+        $('#custom_type_name').val(type_selected);
+        $('#custom_type_feature').val(type['feature']);
+        $("#custom_type_feature").trigger("keyup");
+        $.each(type['tags'], function (key, value) {
+            var tag_value = key.replace(': ', '=');
+            if (value.length > 0) {
+                tag_value += '=' + value.join();
+            }
+            if (type['feature'] != tag_value) {
+                addNewCustomTags(tag_value)
+            }
+        });
+        $('#easy-format #btn-add-custom-type').html('Save');
+        $('#yaml-format #btn-add-custom-type').html('Save');
+
+        {# init for yaml format #}
+        var yamlType = $.extend({}, type);
+        delete yamlType['insights'];
+        delete yamlType['custom'];
+
+        var tags = [];
+        $.each(yamlType['tags'], function (key, value) {
+            if (value.length == 0) {
+                var keys = key.split(': ');
+                if (keys[1]) {
+                    var thisTag = {};
+                    var thisTagKeys = keys[1].split(',');
+                    $.each(thisTagKeys, function (index, value) {
+                        thisTagKeys[index] = $.trim(value);
+                    });
+                    thisTag[keys[0]] = thisTagKeys;
+                    tags.push(thisTag);
+                } else {
+                    tags.push(key);
+                }
+            } else {
+                var thisTag = {};
+                thisTag[key] = value;
+                tags.push(thisTag);
+            }
+        });
+        yamlType['tags'] = tags;
+        var cleanYamlType = {};
+        cleanYamlType[type_selected] = yamlType;
+        $('#yaml-input').val(
+            $('#yaml-input').val() + jsyaml.dump(cleanYamlType)
+        );
+    }
+    function switchToYamlFormat() {
+        $('#yaml-format').show();
+        $('#easy-format').hide();
+    }
+    function switchToEasyFormat() {
+        $('#yaml-format').hide();
+        $('#easy-format').show();
+    }
     function addCustomType(typeData) {
         types[typeData['type']] = {
             feature: typeData['feature'],
@@ -156,12 +295,15 @@
         };
     }
     function modalReset() {
+        rowElements = {};
         $('#custom-types-tags .modal-title').html('+ Add custom type');
         $('#btn-add-custom-type').html('Add');
         $('#custom_type_name').val('');
         $('#custom_type_feature').val('');
         $('#custom-tags').html('');
         $('.modal-required-message').hide()
+        $('#yaml-input').val($('#yaml-input').html());
+        $('#switch-to-easy-format').show();
     }
     function addNewCustomTags(value, is_required) {
         if (!is_required || $('#required-custom-tag-row').length == 0) {
@@ -193,7 +335,7 @@
                 "MapperEngagement"
             ],
             tags: {},
-            custom: true,
+            custom: true
         };
         $('.custom-tag-input').each(function (i, tag) {
             var vals = $(tag).val().split('=');
@@ -234,13 +376,72 @@
         });
         {# save if there is no error #}
         if ($('.modal-required-message:visible').length === 0) {
-            if (lastTypeRow) {
-                $(lastTypeRow).remove();
-            }
-            $('#custom-types-tags').modal('toggle');
             var customType = customTypeToTypeFormat();
-            types[customType['custom_type_name']] = customType['custom_type_value'];
-            addTypes(customType['custom_type_name'])
+            var name = customType['custom_type_name'];
+            var value = customType['custom_type_value'];
+            if (!rowElements[name] && types[name]) {
+                $('.modal-footer .modal-required-message').show();
+            } else {
+                $(rowElements[name]).remove();
+                $('#custom-types-tags').modal('toggle');
+                types[name] = value;
+                addTypes(name)
+            }
+        }
+    }
+
+    function saveYamlCustomType() {
+        $('.modal-required-message,.modal-error-message').hide();
+        try {
+            var data = jsyaml.load($('#yaml-input').val());
+            {# check value #}
+            var correctFormat = true;
+            $.each(data, function (key, value) {
+                if (!value['feature'] || !value['tags']) {
+                    $('.modal-error-message').show();
+                    $('.modal-error-message').html('No feature or tags as child of ' + key);
+                    correctFormat = false;
+                }
+                if (!rowElements[key] && types[key]) {
+                    $('.modal-footer .modal-required-message').show();
+                    correctFormat = false;
+                }
+                var cleanTags = {};
+                if (value['tags'] && value['feature']) {
+                    $.each(value['tags'], function (index, value) {
+                        if (jQuery.type(value) === 'string') {
+                            cleanTags[value] = []
+                        } else {
+                            var firstKey = Object.keys(value)[0];
+                            cleanTags[firstKey] = value[firstKey];
+                        }
+                    });
+                    {# tags for features #}
+                    var features = value['feature'].split('=');
+                    cleanTags[features[0]] = [];
+                    if (features[1]) {
+                        cleanTags[features[0]] = features[1].split(',');
+                    }
+                }
+                value['custom'] = true;
+                value['insights'] = [
+                    "FeatureAttributeCompleteness",
+                    "CountFeature",
+                    "MapperEngagement"
+                ];
+                value['tags'] = cleanTags;
+            });
+            if (correctFormat) {
+                $.each(data, function (key, value) {
+                    $(rowElements[key]).closest('.row').remove();
+                    types[key] = value;
+                    addTypes(key);
+                });
+                $('#custom-types-tags').modal('toggle');
+            }
+        } catch (error) {
+            $('.modal-error-message').show();
+            $('.modal-error-message').html(error.message);
         }
     }
 </script>


### PR DESCRIPTION
this fixes hotosm/field-campaigner/issues/450, fixes hotosm/field-campaigner/issues/448

Is this something like this @smit1678 ?

When user click "add custom type", there is button to change to yaml editor
![selection_032](https://user-images.githubusercontent.com/4530905/43377049-98e431b8-93e8-11e8-886c-8328167ba21b.png)

When user click "Edit custom types in yaml", it will open yaml editor and shows all data of custom types in yaml and can edit/add it .
![selection_033](https://user-images.githubusercontent.com/4530905/43377052-9b49f7bc-93e8-11e8-9eb3-59fa01842743.png)


DEMO : 
https://drive.google.com/file/d/1AFDrlb-QW-NBzBKukJ_3SyJWMku7V63N/view?usp=sharing