### PR TITLE
Generate thumbnail

### DIFF
--- a/.ebextensions/environment.config
+++ b/.ebextensions/environment.config
@@ -12,5 +12,6 @@ option_settings:
     AWS_ACCESS_KEY_ID: SET_AWS_ACCESS_KEY_ID
     AWS_SECRET_ACCESS_KEY: SET_AWS_SECRET_ACCESS_KEY
     AWS_DEFAULT_REGION: us-west-2
+    MAPBOX_TOKEN: SET_MAPBOX_TOKEN
   aws:elasticbeanstalk:container:python:staticfiles:
     /static/: flask_project/campaign_manager/static/

--- a/flask_project/campaign_manager/aws.py
+++ b/flask_project/campaign_manager/aws.py
@@ -174,3 +174,6 @@ class S3Data(object):
         return '{bucket_url}/campaigns/{uuid}'.format(
             bucket_url=self.bucket_url(),
             uuid=uuid)
+
+    def thumbnail_url(self, uuid):
+        return "{url}/thumbnail.png".format(url=self.url(uuid))

--- a/flask_project/campaign_manager/templates/index.html
+++ b/flask_project/campaign_manager/templates/index.html
@@ -716,7 +716,7 @@
                                                 '</div>'+
                                             '</div>'+
                                             '<div class="col-xs-4 campaign-thumbnail">'+
-                                                '<img src="/thumbnail/'+campaign['thumbnail']+'">'+
+                                                '<img src="'+campaign['thumbnail']+'">'+
                                             '</div>'+
                                         '</div>'+
                                         '<div class="row">'+


### PR DESCRIPTION
The code that generated the static map was called during the processing of one insight function.
It is now called after campaign creation (and edition).

However there is still an issue:
on the actual production:

![capture d ecran 2018-09-05 a 14 44 37](https://user-images.githubusercontent.com/35932320/45093967-50f06d00-b11a-11e8-8159-57e606749aca.png)


on my local machine:
![capture d ecran 2018-09-05 a 14 46 30](https://user-images.githubusercontent.com/35932320/45094056-84cb9280-b11a-11e8-9381-0102d83cd37e.png)


