### PR TITLE
add eb config for https

### DIFF
--- a/.ebextensions/https.config
+++ b/.ebextensions/https.config
@@ -1,0 +1,16 @@
+files:
+  "/etc/nginx/conf.d/proxy.conf":
+    mode: "000644"
+    owner: root
+    group: root
+    content: |
+      server {
+         listen 80;
+         if ($http_x_forwarded_proto != 'https') {
+             return 301 https://$host$request_uri;
+         }
+      }
+      
+container_commands:
+  01_reload_nginx:
+    command: "sudo service nginx reload"


### PR DESCRIPTION
Adds an EB extensions file to create a nginx configuration file that forces https. 

@pierrealixt @dakotabenjamin I _think_ this is the right method. Since we're using a load balancer the listens on `80` or `443`, but the connection between the load balancer and the instance is only port `80` we need to check the header. 